### PR TITLE
Session/12

### DIFF
--- a/iOS-training.xcodeproj/project.pbxproj
+++ b/iOS-training.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3510B2BF2A5E68EB00ADAD10 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 3510B2BE2A5E68EB00ADAD10 /* YumemiWeather */; };
 		351DE9E52AD8EA1200227215 /* FetchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351DE9E42AD8EA1200227215 /* FetchManager.swift */; };
 		353A7C312A5D33840038391A /* SwiftFormat in Frameworks */ = {isa = PBXBuildFile; productRef = 353A7C302A5D33840038391A /* SwiftFormat */; };
+		356626F12AE2507100466C7E /* FetchStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356626F02AE2507100466C7E /* FetchStateMachine.swift */; };
 		357FE9482A5EA08100F02DA9 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357FE9472A5EA08100F02DA9 /* Weather.swift */; };
 		35CF2A282A5FC66D001D6E24 /* WeatherAPIImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CF2A272A5FC66D001D6E24 /* WeatherAPIImpl.swift */; };
 		35DB58D22A5BB42900EFF284 /* iOS_trainingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DB58D12A5BB42900EFF284 /* iOS_trainingApp.swift */; };
@@ -47,6 +48,7 @@
 
 /* Begin PBXFileReference section */
 		351DE9E42AD8EA1200227215 /* FetchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchManager.swift; sourceTree = "<group>"; };
+		356626F02AE2507100466C7E /* FetchStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStateMachine.swift; sourceTree = "<group>"; };
 		357FE9472A5EA08100F02DA9 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		35CF2A272A5FC66D001D6E24 /* WeatherAPIImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIImpl.swift; sourceTree = "<group>"; };
 		35DB58CE2A5BB42900EFF284 /* iOS-training.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-training.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				351DE9E42AD8EA1200227215 /* FetchManager.swift */,
+				356626F02AE2507100466C7E /* FetchStateMachine.swift */,
 			);
 			path = MediumModels;
 			sourceTree = "<group>";
@@ -343,6 +346,7 @@
 			files = (
 				35CF2A282A5FC66D001D6E24 /* WeatherAPIImpl.swift in Sources */,
 				35FA06AE2A610BD4000A99D7 /* WeatherIcon.swift in Sources */,
+				356626F12AE2507100466C7E /* FetchStateMachine.swift in Sources */,
 				35DD0CD12AC68C8F0083A461 /* WeatherAPIStub.swift in Sources */,
 				35DB58D42A5BB42900EFF284 /* ContentView.swift in Sources */,
 				35FA06AB2A60D759000A99D7 /* WeatherDateTemperature.swift in Sources */,

--- a/iOS-training.xcodeproj/project.pbxproj
+++ b/iOS-training.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3510B2BF2A5E68EB00ADAD10 /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = 3510B2BE2A5E68EB00ADAD10 /* YumemiWeather */; };
-		351DE9E52AD8EA1200227215 /* FetchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351DE9E42AD8EA1200227215 /* FetchManager.swift */; };
+		351DE9E52AD8EA1200227215 /* FetchTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351DE9E42AD8EA1200227215 /* FetchTaskManager.swift */; };
 		353A7C312A5D33840038391A /* SwiftFormat in Frameworks */ = {isa = PBXBuildFile; productRef = 353A7C302A5D33840038391A /* SwiftFormat */; };
 		356626F12AE2507100466C7E /* FetchStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356626F02AE2507100466C7E /* FetchStateMachine.swift */; };
 		357FE9482A5EA08100F02DA9 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357FE9472A5EA08100F02DA9 /* Weather.swift */; };
@@ -47,7 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		351DE9E42AD8EA1200227215 /* FetchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchManager.swift; sourceTree = "<group>"; };
+		351DE9E42AD8EA1200227215 /* FetchTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchTaskManager.swift; sourceTree = "<group>"; };
 		356626F02AE2507100466C7E /* FetchStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStateMachine.swift; sourceTree = "<group>"; };
 		357FE9472A5EA08100F02DA9 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		35CF2A272A5FC66D001D6E24 /* WeatherAPIImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIImpl.swift; sourceTree = "<group>"; };
@@ -100,7 +100,7 @@
 		351DE9E62AD8EC5E00227215 /* MediumModels */ = {
 			isa = PBXGroup;
 			children = (
-				351DE9E42AD8EA1200227215 /* FetchManager.swift */,
+				351DE9E42AD8EA1200227215 /* FetchTaskManager.swift */,
 				356626F02AE2507100466C7E /* FetchStateMachine.swift */,
 			);
 			path = MediumModels;
@@ -350,7 +350,7 @@
 				35DD0CD12AC68C8F0083A461 /* WeatherAPIStub.swift in Sources */,
 				35DB58D42A5BB42900EFF284 /* ContentView.swift in Sources */,
 				35FA06AB2A60D759000A99D7 /* WeatherDateTemperature.swift in Sources */,
-				351DE9E52AD8EA1200227215 /* FetchManager.swift in Sources */,
+				351DE9E52AD8EA1200227215 /* FetchTaskManager.swift in Sources */,
 				35FD89602AC3EC5E002E6D69 /* WeatherAPI.swift in Sources */,
 				35DB58D22A5BB42900EFF284 /* iOS_trainingApp.swift in Sources */,
 				357FE9482A5EA08100F02DA9 /* Weather.swift in Sources */,

--- a/iOS-training/ContentView.swift
+++ b/iOS-training/ContentView.swift
@@ -26,6 +26,10 @@ struct ContentView: View {
         (weatherInfo?.maxTemperature).map(String.init) ?? "--"
     }
 
+    private var isFetching: Bool {
+        weatherFetchManager.isFetching
+    }
+
     private var error: Error? {
         weatherFetchManager.error
     }
@@ -43,7 +47,18 @@ struct ContentView: View {
                     length / 2
                 }
                 .overlay {
-                    WeatherIcon(weatherInfo?.weatherCondition)
+                    ZStack {
+                        WeatherIcon(weatherInfo?.weatherCondition)
+                        if isFetching {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .padding()
+                                .background {
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .foregroundStyle(.ultraThinMaterial)
+                                }
+                        }
+                    }
                 }
 
             HStack(spacing: .zero) {

--- a/iOS-training/ContentView.swift
+++ b/iOS-training/ContentView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    init(weatherFetchManager: FetchManager<WeatherDateTemperature>) {
+    init(weatherFetchManager: FetchTaskManager<WeatherDateTemperature>) {
         _weatherFetchManager = State(initialValue: weatherFetchManager)
     }
 
-    @State private var weatherFetchManager: FetchManager<WeatherDateTemperature>
+    @State private var weatherFetchManager: FetchTaskManager<WeatherDateTemperature>
 
     private var weatherInfo: WeatherDateTemperature? {
         weatherFetchManager.fetched
@@ -104,6 +104,6 @@ struct ContentView: View {
 }
 
 #Preview {
-    let fetchingMethod = { try WeatherAPIStub().fetchWeatherCondition(of: .sunny) }
-    return ContentView(weatherFetchManager: FetchManager(for: fetchingMethod))
+    let fetchingMethod = { try await WeatherAPIStub().fetchWeatherCondition(in: "tokyo", at: Date()) }
+    return ContentView(weatherFetchManager: FetchTaskManager(for: fetchingMethod))
 }

--- a/iOS-training/CoreModels/WeatherAPI.swift
+++ b/iOS-training/CoreModels/WeatherAPI.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 protocol WeatherAPI {
-    func fetchWeatherCondition(in area: String, at date: Date) throws -> WeatherDateTemperature
+    func fetchWeatherCondition(in area: String, at date: Date) async throws -> WeatherDateTemperature
 }

--- a/iOS-training/CoreModels/WeatherAPIImpl.swift
+++ b/iOS-training/CoreModels/WeatherAPIImpl.swift
@@ -9,11 +9,11 @@ import Foundation
 import YumemiWeather
 
 struct WeatherAPIImpl: WeatherAPI {
-    func fetchWeatherCondition(in area: String, at date: Date) throws -> WeatherDateTemperature {
+    func fetchWeatherCondition(in area: String, at date: Date) async throws -> WeatherDateTemperature {
         // MARK: Encoding into input JSON String
         
         let requestJSON = try WeatherRequestGenerator().generate(area: area, date: date)
-        let fetchedWeatherJSON = try YumemiWeather.fetchWeather(requestJSON) // may throw YumemiWeatherError.invalidParameterError and \.unknownError
+        let fetchedWeatherJSON = try await YumemiWeather.asyncFetchWeather(requestJSON) // may throw YumemiWeatherError.invalidParameterError and \.unknownError
         let weatherDateTemperature = try WeatherDateTemperatureGenerator().generate(from: fetchedWeatherJSON)
         return weatherDateTemperature
     }

--- a/iOS-training/MediumModels/FetchStateMachine.swift
+++ b/iOS-training/MediumModels/FetchStateMachine.swift
@@ -1,0 +1,44 @@
+//
+//  FetchStateMachine.swift
+//  iOS-training
+//
+//  Created by 松本 幸太郎 on 2023/10/20.
+//
+
+import Foundation
+
+struct FetchStateMachine<Success, Failure> where Failure: Error {
+    private(set) var state: FetchState = .initial
+    private var result: Result<Success, Failure>?
+    
+    var product: Success? {
+        try? result?.get()
+    }
+    
+    var error: Failure? {
+        if case let .failure(e) = result {
+            e
+        } else {
+            nil
+        }
+    }
+    
+    mutating func start() { state = .isFetching }
+    mutating func stop() { state = result == nil ? .initial : .fetched }
+    
+    mutating func finish(with value: Result<Success, Failure>) {
+        result = value
+        state = .fetched
+    }
+    
+    mutating func reset() {
+        result = nil
+        state = .initial
+    }
+}
+
+enum FetchState {
+    case initial
+    case isFetching
+    case fetched
+}

--- a/iOS-training/Preview Content/WeatherAPIStub.swift
+++ b/iOS-training/Preview Content/WeatherAPIStub.swift
@@ -9,7 +9,7 @@ import Foundation
 import YumemiWeather
 
 struct WeatherAPIStub: WeatherAPI {
-    func fetchWeatherCondition(in _: String, at _: Date) throws -> WeatherDateTemperature {
+    func fetchWeatherCondition(in _: String, at _: Date) async throws -> WeatherDateTemperature {
         let date = Date(timeIntervalSince1970: 0)
         let weatherDateTemperature = WeatherDateTemperature(maxTemperature: 30,
                                                             date: date,

--- a/iOS-training/iOS_trainingApp.swift
+++ b/iOS-training/iOS_trainingApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct iOS_trainingApp: App {
     private let weatherFetchManager: FetchManager<WeatherDateTemperature> = {
-        let fetchingMethod = { try WeatherAPIImpl().fetchWeatherCondition(in: "tokyo", at: Date()) }
+        let fetchingMethod = { try await WeatherAPIImpl().fetchWeatherCondition(in: "tokyo", at: Date()) }
         return FetchManager(for: fetchingMethod)
     }()
     

--- a/iOS-training/iOS_trainingApp.swift
+++ b/iOS-training/iOS_trainingApp.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 @main
 struct iOS_trainingApp: App {
-    private let weatherFetchManager: FetchManager<WeatherDateTemperature> = {
+    private let weatherFetchManager: FetchTaskManager<WeatherDateTemperature> = {
         let fetchingMethod = { try await WeatherAPIImpl().fetchWeatherCondition(in: "tokyo", at: Date()) }
-        return FetchManager(for: fetchingMethod)
+        return FetchTaskManager(for: fetchingMethod)
     }()
     
     var body: some Scene {

--- a/iOS-trainingTests/ios_trainingSnapshotTests.swift
+++ b/iOS-trainingTests/ios_trainingSnapshotTests.swift
@@ -16,7 +16,7 @@ class LayoutPrototypeTests: XCTestCase {
     private let view: UIView = {
         // Setting up weatherFetchManager
         let fetchingMethod = { WeatherAPIStub().fetchWeatherCondition(of: .sunny) }
-        let weatherFetchManager: FetchManager<WeatherDateTemperature> = FetchManager(for: fetchingMethod)
+        let weatherFetchManager: FetchTaskManager<WeatherDateTemperature> = FetchTaskManager(for: fetchingMethod)
         weatherFetchManager.fetch()
         return UIHostingController(rootView: ContentView(weatherFetchManager: weatherFetchManager)).view
     }()


### PR DESCRIPTION
# 本来の課題
https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Concurrency.md
- Delegateで受け取っていたAPIの結果を、コンカレンシー形式で受け取るように変更する
- ViewControllerを閉じた時にdeinitが呼ばれることを確認する

# したこと
- [Session10](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md)の`qsyncFetchWeather`をConcurrencyで実装。
-  非同期処理を管理する`FetchTaskManager`と処理の状態を保持・管理する`FetchStateMachine`を追加した。
- ProgressViewを追加。

# していないこと
本来の課題のうち、`ViewControllerを閉じた時にdeinitが呼ばれることを確認する`は実施していません。理由としては、SwiftUIの場合`class`ではなく`struct`を主に使用しますが、`struct`は`deinit`に対応していないためです。
